### PR TITLE
🪲 [Fix]: Don't count filtered tests as failed tests

### DIFF
--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -114,7 +114,6 @@ foreach ($expected in $expectedTestSuites) {
     $hasPassedValue = $null -ne $result.Passed
     $hasFailedValue = $null -ne $result.Failed
     $hasInconclusiveValue = $null -ne $result.Inconclusive
-    $hasNotRunValue = $null -ne $result.NotRun
 
     $testFailure = (
         $result.Result -ne 'Passed' -or
@@ -123,8 +122,7 @@ foreach ($expected in $expectedTestSuites) {
         ($hasTestsValue -and $result.Tests -eq 0) -or
         ($hasPassedValue -and $hasTestsValue -and $result.Tests -gt 0 -and $result.Passed -eq 0) -or
         ($hasFailedValue -and $result.Failed -gt 0) -or
-        ($hasInconclusiveValue -and $result.Inconclusive -gt 0) -or
-        ($hasNotRunValue -and $result.NotRun -gt 0)
+        ($hasInconclusiveValue -and $result.Inconclusive -gt 0)
     )
 
     if ($testFailure) {
@@ -177,10 +175,6 @@ foreach ($expected in $expectedTestSuites) {
 
         if ($hasInconclusiveValue -and $result.Inconclusive -gt 0) {
             $null = $failureReasons.Add("$($result.Inconclusive) tests were inconclusive in file: $($expected.Name)")
-        }
-
-        if ($hasNotRunValue -and $result.NotRun -gt 0) {
-            $null = $failureReasons.Add("$($result.NotRun) tests were not run in file: $($expected.Name)")
         }
 
         foreach ($reason in $failureReasons) {


### PR DESCRIPTION
## Description

This pull request simplifies the test result handling logic in the `scripts/main.ps1` file by removing all checks and reporting related to tests that were "NotRun". The script now only considers passed, failed, and inconclusive tests when determining test failures and reporting errors.

Test result handling simplification:

* Removed all logic related to the `NotRun` test status, including the `$hasNotRunValue` variable, checks for `NotRun` in test failure conditions, and error reporting for tests that were not run. [[1]](diffhunk://#diff-dc2e5a659836b1b73abb03421c567f5018c2755677c4a0aa764cb26117b68011L117) [[2]](diffhunk://#diff-dc2e5a659836b1b73abb03421c567f5018c2755677c4a0aa764cb26117b68011L126-R125) [[3]](diffhunk://#diff-dc2e5a659836b1b73abb03421c567f5018c2755677c4a0aa764cb26117b68011L182-L185)